### PR TITLE
Updating clumio_post_process_aws_connection DynamoDB Policy Reference w/ Condition

### DIFF
--- a/main.tf.json
+++ b/main.tf.json
@@ -1565,8 +1565,8 @@
                     ],
                     "discover_version": "4.2",
                     "properties": {
-                        "DynamoDbSecureVaultPolicyArn": "${aws_iam_policy.clumio_dynamodb_policy[0].arn}",
-                        "DynamoDbWarmProtectPolicyArn": "${aws_iam_policy.clumio_warm_protect_dynamodb_policy[0].arn}",
+                        "DynamoDbSecureVaultPolicyArn": "${var.is_protect_enabled && var.is_dynamodb_enabled ? aws_iam_policy.clumio_dynamodb_policy[0].arn : \"\"}",
+                        "DynamoDbWarmProtectPolicyArn": "${var.is_protect_enabled && var.is_dynamodb_enabled ? aws_iam_policy.clumio_warm_protect_dynamodb_policy[0].arn : \"\"}",
                         "PermissionsBoundaryArn": "${aws_iam_policy.clumio_iam_permissions_boundary.arn}"
                     },
                     "protect_config_version": "${var.is_protect_enabled ? \"19.2\" : \"\"}",


### PR DESCRIPTION
The properties `DynamoDbSecureVaultPolicyArn` and `DynamoDbWarmProtectPolicyArn` were failing with the following errors:

```
│ Error: Invalid index
│
│   on .terraform/modules/clumio_protect_east_1/main.tf.json line 1568, in resource[46].clumio_post_process_aws_connection.clumio_callback.properties:
│ 1568:                         "DynamoDbSecureVaultPolicyArn": "${aws_iam_policy.clumio_dynamodb_policy[0].arn}",
│     ├────────────────
│     │ aws_iam_policy.clumio_dynamodb_policy is empty tuple
│
│ The given key does not identify an element in this collection value: the
│ collection has no elements.
╵
╷
│ Error: Invalid index
│
│   on .terraform/modules/clumio_protect_east_1/main.tf.json line 1569, in resource[46].clumio_post_process_aws_connection.clumio_callback.properties:
│ 1569:                         "DynamoDbWarmProtectPolicyArn": "${aws_iam_policy.clumio_warm_protect_dynamodb_policy[0].arn}",
│     ├────────────────
│     │ aws_iam_policy.clumio_warm_protect_dynamodb_policy is empty tuple
│
│ The given key does not identify an element in this collection value: the
│ collection has no elements.
```

Since `aws_iam_policy.clumio_dynamodb_policy` and `aws_iam_policy.clumio_warm_protect_dynamodb_policy` are created conditionally, you have to add a condition when referencing the resources as well. 