### PR TITLE
pemissions boundary added for the s3 continuous backup role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.12.2
+Added permissions boundary to the clumio_s3_continuous_backup_event_bridge_role resource.
+
 ## 0.12.1
 Updated required provider version for clumio to ~>0.5.0 and documentation updates.
 

--- a/main.tf.json
+++ b/main.tf.json
@@ -1636,6 +1636,7 @@
                     ],
                     "name": "ClumioS3EbRole-${lookup(local.region_map, var.aws_region, \"\")}-${var.clumio_token}",
                     "path": "${var.path}",
+                    "permissions_boundary": "${var.permissions_boundary_arn}",
                     "tags": "${var.clumio_iam_role_tags}"
                 }
             }


### PR DESCRIPTION
pemissions boundary added for the s3 continuous backup role