### PR TITLE
Fix an issue on ListProtectedResources permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.33.2
+Fixed a bug in AWS backup statement.
+
 ## 0.33.1
 Changed the Clumio provider version required to >=0.14.0, <0.16.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.33.2
-Fixed a bug on ListProtectedResources permission.
+Fixed an issue on ListProtectedResources permission.
 
 ## 0.33.1
 Changed the Clumio provider version required to >=0.14.0, <0.16.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.33.2
-Fixed a bug in AWS backup statement.
+Fixed a bug on ListProtectedResources permission.
 
 ## 0.33.1
 Changed the Clumio provider version required to >=0.14.0, <0.16.0.

--- a/common.tf
+++ b/common.tf
@@ -264,7 +264,7 @@ data "aws_iam_policy_document" "clumio_event_pub_policy_document" {
 data "aws_iam_policy_document" "clumio_inventory_policy_document" {
   # Allow Clumio insight into other AWS-backed up resources
   dynamic "statement" {
-    for_each = var.is_s3_enabled && var.collect_inventory_aws_backup_recovery_points ? [1] : []
+    for_each = var.is_s3_enabled || var.collect_inventory_aws_backup_recovery_points ? [1] : []
     content {
       actions = [
         "backup:ListProtectedResources"


### PR DESCRIPTION
Summary:

Currently backup:ListProtectedResources is enabled only if below condition is satisfied
```
var.is_s3_enabled && var.collect_inventory_aws_backup_recovery_points
```
But this should actually be like below to match the permissions defined in CFT
```
var.is_s3_enabled || var.collect_inventory_aws_backup_recovery_points
```