### PR TITLE
Update required Clumio provider version to >=0.20.0, <0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.38.1
+* Changed the Clumio provider version required to >=0.20.0, <0.22.0.
+
 ## 0.38.0
 * Improved RDS restore support for validating and restoring parameter group configurations.
 * Tightened S3 continuous backup role trust conditions.

--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ module "clumio_aws_connection_module" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_clumio"></a> [clumio](#requirement\_clumio) | >=0.19.0, <0.21.0 |
+| <a name="requirement_clumio"></a> [clumio](#requirement\_clumio) | >=0.20.0, <0.22.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_clumio"></a> [clumio](#provider\_clumio) | >=0.19.0, <0.21.0 |
+| <a name="provider_clumio"></a> [clumio](#provider\_clumio) | >=0.20.0, <0.22.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | n/a |
 
 ## Modules

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
     aws = {}
     clumio = {
       source  = "clumio-code/clumio"
-      version = ">=0.19.0, <0.21.0"
+      version = ">=0.20.0, <0.22.0"
     }
   }
 }


### PR DESCRIPTION
Summary:
- Updates the required Clumio provider version from `>=0.19.0, <0.21.0` to `>=0.20.0, <0.22.0`.
- Bumps the module to 0.38.1.