### PR TITLE
Update required Clumio provider version to >=0.21.0, <0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.38.2
+* Changed the Clumio provider version required to >=0.21.0, <0.23.0.
+
 ## 0.38.1
 * Changed the Clumio provider version required to >=0.20.0, <0.22.0.
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
     aws = {}
     clumio = {
       source  = "clumio-code/clumio"
-      version = ">=0.20.0, <0.22.0"
+      version = ">=0.21.0, <0.23.0"
     }
   }
 }


### PR DESCRIPTION
Bumps the required Clumio provider version to `>=0.21.0, <0.23.0` so the module can be used with provider `0.22.0`. CHANGELOG updated. No template content changes.
