### PR TITLE
Release 0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.39.0
+* Added Glue column statistics and S3 bucket location permissions for Iceberg on AWS Glue.
+* Restricted the tag-change event rule to the resource types of the enabled data sources.
+* Changed the Clumio provider version required to >=0.22.0, <0.24.0.
+* Marked the API token variable in the example as sensitive.
+
 ## 0.38.3
 * Improved documentation for module variables.
 

--- a/README.md
+++ b/README.md
@@ -102,14 +102,14 @@ module "clumio_aws_connection_module" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_clumio"></a> [clumio](#requirement\_clumio) | >=0.21.0, <0.23.0 |
+| <a name="requirement_clumio"></a> [clumio](#requirement\_clumio) | >=0.22.0, <0.24.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_clumio"></a> [clumio](#provider\_clumio) | >=0.21.0, <0.23.0 |
+| <a name="provider_clumio"></a> [clumio](#provider\_clumio) | >=0.22.0, <0.24.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | n/a |
 
 ## Modules

--- a/common.tf
+++ b/common.tf
@@ -42,8 +42,20 @@ locals {
 
 locals {
   should_create_tag_event_rule = var.is_ebs_enabled || var.is_dynamodb_enabled || var.is_rds_enabled || var.is_s3_enabled || var.is_iceberg_on_s3_tables_enabled
-  tag_event_rule_data_sources  = jsonencode(compact(concat(var.is_ebs_enabled ? ["ebs", "ec2"] : [""], var.is_rds_enabled ? ["rds"] : [""], var.is_dynamodb_enabled ? ["dynamodb"] : [""], var.is_s3_enabled ? ["s3"] : [""], var.is_iceberg_on_s3_tables_enabled ? ["s3tables"] : [""])))
-  tag_event_rule_event_pattern = format("{\"detail\":{\"service\":%s},\"source\":[\"aws.tag\"]}", local.tag_event_rule_data_sources)
+  tag_event_rule_services      = compact(concat(var.is_ebs_enabled ? ["ec2"] : [""], var.is_rds_enabled ? ["rds"] : [""], var.is_dynamodb_enabled ? ["dynamodb"] : [""], var.is_s3_enabled ? ["s3"] : [""], var.is_iceberg_on_s3_tables_enabled ? ["s3tables"] : [""]))
+  tag_event_rule_resource_types = distinct(concat(
+    var.is_ebs_enabled ? ["instance", "image", "volume", "snapshot", ""] : [],
+    var.is_rds_enabled ? ["db", "cluster", "snapshot", "cluster-snapshot", ""] : [],
+    var.is_dynamodb_enabled ? ["table", ""] : [],
+    var.is_s3_enabled ? ["", "bucket"] : [],
+  var.is_iceberg_on_s3_tables_enabled ? ["bucket", ""] : []))
+  tag_event_rule_event_pattern = jsonencode({
+    "detail" : {
+      "service" : local.tag_event_rule_services,
+      "resource-type" : concat(local.tag_event_rule_resource_types, [{ "exists" : false }]),
+    },
+    "source" : ["aws.tag"],
+  })
 }
 
 data "aws_caller_identity" "current" {
@@ -1103,15 +1115,15 @@ resource "clumio_post_process_aws_connection" "clumio_callback" {
     "ClumioInventoryTopicEncryptionKey" : var.clumio_inventory_sns_topic_encryption_key
   }
   protect_config_version               = "26.0"
-  protect_dynamodb_version             = var.is_dynamodb_enabled ? "8.0" : ""
-  protect_ebs_version                  = var.is_ebs_enabled ? "27.0" : ""
+  protect_dynamodb_version             = var.is_dynamodb_enabled ? "8.1" : ""
+  protect_ebs_version                  = var.is_ebs_enabled ? "27.1" : ""
   protect_ec2_mssql_version            = var.is_ec2_mssql_enabled ? "5.0" : ""
-  protect_rds_version                  = var.is_rds_enabled ? "23.0" : ""
-  protect_s3_version                   = var.is_s3_enabled ? "9.1" : ""
-  protect_warm_tier_dynamodb_version   = var.is_dynamodb_enabled ? "8.0" : ""
+  protect_rds_version                  = var.is_rds_enabled ? "23.2" : ""
+  protect_s3_version                   = var.is_s3_enabled ? "9.2" : ""
+  protect_warm_tier_dynamodb_version   = var.is_dynamodb_enabled ? "8.1" : ""
   protect_warm_tier_version            = var.is_dynamodb_enabled ? "1.1" : ""
-  protect_iceberg_on_glue_version      = var.is_iceberg_on_glue_enabled ? "3.0" : ""
-  protect_iceberg_on_s3_tables_version = var.is_iceberg_on_s3_tables_enabled ? "3.0" : ""
+  protect_iceberg_on_glue_version      = var.is_iceberg_on_glue_enabled ? "4.0" : ""
+  protect_iceberg_on_s3_tables_version = var.is_iceberg_on_s3_tables_enabled ? "3.1" : ""
   region                               = var.aws_region
   role_arn                             = aws_iam_role.clumio_iam_role.arn
   role_external_id                     = var.role_external_id

--- a/examples/all_data_sources/variables.tf
+++ b/examples/all_data_sources/variables.tf
@@ -1,6 +1,7 @@
 variable "clumio_api_token" {
   description = "API Token required to invoke Clumio APIs."
   type        = string
+  sensitive   = true
 }
 
 variable "clumio_api_base_url" {

--- a/examples/all_data_sources/versions.tf
+++ b/examples/all_data_sources/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     clumio = {
       source  = "clumio-code/clumio"
-      version = ">=0.14.0, <0.16.0"
+      version = ">=0.22.0, <0.24.0"
     }
     aws = {}
   }

--- a/iceberg_on_glue.tf
+++ b/iceberg_on_glue.tf
@@ -31,6 +31,7 @@ data "aws_iam_policy_document" "clumio_iceberg_on_glue_backup_policy_document" {
   statement {
     actions = [
       "s3:GetObject",
+      "s3:GetBucketLocation",
     ]
 
     condition {
@@ -115,6 +116,9 @@ data "aws_iam_policy_document" "clumio_iceberg_on_glue_restore_policy_document" 
       "glue:GetTable",
       "glue:CreateTable",
       "glue:UpdateTable",
+      "glue:UpdateColumnStatisticsForTable",
+      "glue:GetColumnStatisticsForTable",
+      "glue:DeleteColumnStatisticsForTable",
       "glue:GetTableOptimizer",
       "glue:CreateTableOptimizer",
       "glue:GetDatabase",

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
     aws = {}
     clumio = {
       source  = "clumio-code/clumio"
-      version = ">=0.21.0, <0.23.0"
+      version = ">=0.22.0, <0.24.0"
     }
   }
 }


### PR DESCRIPTION
Summary:
* Added Glue column statistics and S3 bucket location permissions for Iceberg on AWS Glue.
* Restricted the tag-change event rule to the resource types of the enabled data sources.
* Changed the Clumio provider version required to >=0.22.0, <0.24.0.
* Marked the API token variable in the example as sensitive.
